### PR TITLE
Create simple GitHub Pages landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # TESTE_CODEX
-Teste com o CODEX para geração de GitHub Pages
+
+Este repositório contém uma página estática simples para validar o fluxo de publicação com o GitHub Pages.
+
+## Visualizar localmente
+
+Basta abrir o arquivo [`index.html`](./index.html) em qualquer navegador para visualizar a página.
+
+## Publicar no GitHub Pages
+
+1. Acesse as configurações do repositório no GitHub.
+2. Em **Pages**, escolha o branch que deseja publicar (por exemplo, `main`).
+3. Defina a pasta `/` (raiz) como origem e salve.
+4. Aguarde alguns instantes para que o GitHub faça o deploy automático.
+
+Após o deploy, sua página estará disponível em `https://<usuario>.github.io/<nome-do-repositorio>/`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TESTE_CODEX | GitHub Pages</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <h1>TESTE_CODEX</h1>
+        <p class="tagline">Uma página simples hospedada com GitHub Pages</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <h2>Bem-vindo!</h2>
+        <p>
+          Esta é uma página estática de exemplo criada para validar a integração
+          com o GitHub Pages. Ela usa apenas HTML e CSS e pode ser publicada
+          diretamente a partir deste repositório.
+        </p>
+      </section>
+
+      <section class="card">
+        <h2>Como publicar</h2>
+        <ol>
+          <li>
+            Abra as configurações do repositório no GitHub e acesse a seção
+            <strong>Pages</strong>.
+          </li>
+          <li>
+            Em <em>Source</em>, selecione o branch desejado (por exemplo,
+            <code>main</code>) e a pasta <code>/</code> (raiz) como origem.
+          </li>
+          <li>
+            Salve as alterações e aguarde alguns minutos para a página ser
+            disponibilizada.
+          </li>
+        </ol>
+      </section>
+
+      <section class="card">
+        <h2>Próximos passos</h2>
+        <p>
+          Personalize este layout para refletir o seu projeto. Você pode adicionar
+          novas seções, incluir imagens ou mesmo criar páginas adicionais na pasta
+          <code>docs/</code> caso prefira manter a raiz do repositório apenas para
+          código-fonte.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>
+          Feito com ❤ para demonstrar o funcionamento do GitHub Pages.<br />
+          <span class="small">
+            Atualizado em <time id="last-updated"></time>
+          </span>
+        </p>
+      </div>
+    </footer>
+
+    <script>
+      const timeElement = document.getElementById("last-updated");
+      const locale = document.documentElement.lang || "pt-BR";
+      const formatter = new Intl.DateTimeFormat(locale, {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+      });
+      timeElement.textContent = formatter.format(new Date());
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: light dark;
+  --background: #f2f5f9;
+  --foreground: #0b1f33;
+  --muted: #5f7387;
+  --accent: #1f7aed;
+  --card-bg: rgba(255, 255, 255, 0.85);
+  --card-border: rgba(15, 36, 56, 0.08);
+  --shadow: 0 20px 45px rgba(15, 36, 56, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: linear-gradient(135deg, #fdfbfb 0%, #ebedee 100%);
+  color: var(--foreground);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  width: min(960px, 90vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  padding: 4rem 0 2.5rem;
+  text-align: center;
+}
+
+.site-header h1 {
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.site-header .tagline {
+  margin-top: 0.75rem;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  gap: 1.75rem;
+  padding-bottom: 4rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 1rem;
+  padding: 2.25rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+}
+
+.card h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.card p,
+.card li {
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.card ol {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.card code {
+  background: rgba(31, 122, 237, 0.08);
+  color: var(--accent);
+  border-radius: 0.35rem;
+  padding: 0.2rem 0.45rem;
+  font-size: 0.95rem;
+}
+
+.site-footer {
+  padding: 2.5rem 0 1.5rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.site-footer .small {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .card {
+    padding: 1.75rem;
+  }
+
+  .card h2 {
+    font-size: 1.35rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive landing page with guidance on habilitating GitHub Pages
- style the page with a lightweight glassmorphism-inspired theme
- document publishing steps in the README

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68cec4b03b1c832f97b5491d6318c6fa